### PR TITLE
Fix for argcount w.r.t async handler

### DIFF
--- a/atest/asynchronous_messages/my_handler.py
+++ b/atest/asynchronous_messages/my_handler.py
@@ -16,6 +16,8 @@ def reset_received_messages():
 
 
 def respond_to_sample(rammbock, msg, client):
+    foo = "adding Extra Variable to replicate ArgCount bug"
+    bar = "adding Extra Variable to replicate ArgCount bug"
     RECEIVED_MESSAGES.append(msg)
     rammbock.save_template("__backup_template")
     try:

--- a/src/Rammbock/templates/message_stream.py
+++ b/src/Rammbock/templates/message_stream.py
@@ -150,10 +150,10 @@ class MessageStream(object):
     def _call_handler_function(self, func, msg):
         func = self._get_call_handler(func)
         node, connection = self._get_node_and_connection()
-        args = func.func_code.co_varnames
-        if len(args) == 3:
+        args = func.func_code.co_argcount
+        if args == 3:
             return func(self._protocol.library, msg, node)
-        if len(args) == 4:
+        if args == 4:
             return func(self._protocol.library, msg, node, connection)
         return func(self._protocol.library, msg)
 


### PR DESCRIPTION
"argcount" check was broken as it checked the variables count instead of the arguments