### PR TITLE
Adding support for string values for header_filter.

### DIFF
--- a/atest/header_filter.robot
+++ b/atest/header_filter.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Test Setup          Setup up server for test
+Test Teardown       Reset Rammbock
+Library             Rammbock
+Resource            Protocols.robot
+
+*** Test Cases ***
+String message field matching the header filter
+    Define and send example message
+    Receive example message matching filter
+
+String message field not matching the header filter
+    Define and send example message
+    Run keyword and expect error  * timed out  Receive example message with filter value    NOT MATCHING
+
+String message field not matching the header filter with unicode value
+    Define and send example message
+    Run keyword and expect error  * timed out  Receive example message with filter value     देवनागरी
+
+*** Keywords ***
+Setup up server for test
+    Define a protocol with string field in header
+    Setup UDP server and client    protocol=StringInHeader
+
+Define a protocol with string field in header
+    New protocol    StringInHeader
+    Chars     *     string_field 
+    End protocol
+
+Define and send example message
+    New message  exMessage  StringInHeader  header:string_field:match string message
+    Client sends message
+
+Receive example message matching filter
+    New message  exMessage  StringInHeader  header:string_field:match string message
+    Server receives message  header_filter=string_field
+
+Receive example message with filter value
+    [arguments]    ${value}
+    New message  exMessage  StringInHeader  header:string_field:${value}
+    Server receives message  header_filter=string_field

--- a/src/Rammbock/templates/message_stream.py
+++ b/src/Rammbock/templates/message_stream.py
@@ -16,7 +16,7 @@ import threading
 import traceback
 
 from Rammbock.logger import logger
-from Rammbock.binary_tools import to_bin
+from Rammbock.binary_tools import to_bin, to_int
 from Rammbock.synchronization import LOCK
 
 
@@ -94,11 +94,15 @@ class MessageStream(object):
         return msg
 
     def _matches(self, header, fields, header_filter):
-        # FIXME: Matching should not be assuming matching string presentation
         if header_filter:
             if header_filter not in fields:
                 raise AssertionError('Trying to filter messages by header field %s, but no value has been set for %s' %
                                      (header_filter, header_filter))
+            field = header[header_filter]
+            if field._type == 'chars':
+                return field.ascii == fields[header_filter]
+            if field._type == 'uint':
+                return field.uint == to_int(fields[header_filter])
             if header[header_filter].bytes != to_bin(fields[header_filter]):
                 return False
         return True


### PR DESCRIPTION
This will allow us to use string values for header_filter.
The header_filter now checks for the type of header field and then does the comparison accordingly. #47 