### PR TITLE
Adding support for regular expression matching for values of type Chars

### DIFF
--- a/atest/header_filter.robot
+++ b/atest/header_filter.robot
@@ -24,7 +24,7 @@ String message field matching the header filter with regexp
 
 String message field not matching the header filter with regexp
     Define and send example message
-    Run keyword and expect error  * timed out  Receive example message with filter value    REGEXP:.*message.
+    Run keyword and expect error  * timed out  Receive example message with filter value    REGEXP:.*invalid
 
 String message field matching the header filter with invalid regexp
     Define and send example message
@@ -36,7 +36,7 @@ String message field matching the regexp
 
 String message field not matching the regexp
     Define and send example message
-    Run keyword and expect error  * does not match the RegEx *  Receive example message with regexp value    REGEXP:.*message.
+    Run keyword and expect error  * does not match the RegEx *  Receive example message with regexp value    REGEXP:.*invalid
 
 Comparing string message field with an invalid regexp
     Define and send example message
@@ -55,6 +55,10 @@ Comparing integer message field with a regexp
     New message  exMessage  StringInHeader  header:integer_field:REGEXP:.*
     Run keyword and expect error  * can not be matched to regular expression pattern *  Server receives message
 
+String message field matching the header filter with multiple messages in stream
+    Define and send multiple messages
+    Receive example message with filter value    REGEXP:^first
+
 *** Keywords ***
 Setup up server for test
     Define a protocol with string field in header
@@ -63,15 +67,21 @@ Setup up server for test
 Define a protocol with string field in header
     New protocol    StringInHeader
     Uint      1     integer_field
-    Chars     *     string_field
+    Chars     *     string_field    terminator=0x0e
     End protocol
 
 Define and send example message
-    New message  exMessage  StringInHeader  header:string_field:match string message  header:integer_field:10
+    New message  exMessage  StringInHeader  header:string_field:match string message.  header:integer_field:10
+    Client sends message
+
+Define and send multiple messages
+    New message  exMessage1  StringInHeader  header:string_field:first string message.  header:integer_field:10
+	Client sends message
+	New message  exMessage2  StringInHeader  header:string_field:sencond string message.  header:integer_field:10
     Client sends message
 
 Receive example message matching filter
-    New message  exMessage  StringInHeader  header:string_field:match string message
+    New message  exMessage  StringInHeader  header:string_field:match string message.
     Server receives message  header_filter=string_field
 
 Receive example message with filter value

--- a/atest/header_filter.robot
+++ b/atest/header_filter.robot
@@ -67,21 +67,21 @@ Setup up server for test
 Define a protocol with string field in header
     New protocol    StringInHeader
     Uint      1     integer_field
-    Chars     *     string_field    terminator=0x0e
+    Chars     *     string_field    terminator=0x00
     End protocol
 
 Define and send example message
-    New message  exMessage  StringInHeader  header:string_field:match string message.  header:integer_field:10
+    New message  exMessage  StringInHeader  header:string_field:match string message  header:integer_field:10
     Client sends message
 
 Define and send multiple messages
-    New message  exMessage1  StringInHeader  header:string_field:first string message.  header:integer_field:10
+    New message  exMessage1  StringInHeader  header:string_field:first string message  header:integer_field:10
 	Client sends message
-	New message  exMessage2  StringInHeader  header:string_field:sencond string message.  header:integer_field:10
+	New message  exMessage2  StringInHeader  header:string_field:second string message  header:integer_field:10
     Client sends message
 
 Receive example message matching filter
-    New message  exMessage  StringInHeader  header:string_field:match string message.
+    New message  exMessage  StringInHeader  header:string_field:match string message
     Server receives message  header_filter=string_field
 
 Receive example message with filter value

--- a/atest/header_filter.robot
+++ b/atest/header_filter.robot
@@ -3,6 +3,7 @@ Test Setup          Setup up server for test
 Test Teardown       Reset Rammbock
 Library             Rammbock
 Resource            Protocols.robot
+Default Tags        regression
 
 *** Test Cases ***
 String message field matching the header filter
@@ -17,6 +18,43 @@ String message field not matching the header filter with unicode value
     Define and send example message
     Run keyword and expect error  * timed out  Receive example message with filter value     देवनागरी
 
+String message field matching the header filter with regexp
+    Define and send example message
+    Receive example message with filter value    REGEXP:.*message
+
+String message field not matching the header filter with regexp
+    Define and send example message
+    Run keyword and expect error  * timed out  Receive example message with filter value    REGEXP:.*message.
+
+String message field matching the header filter with invalid regexp
+    Define and send example message
+    Run keyword and expect error  Invalid RegEx *  Receive example message with filter value    REGEXP:**
+
+String message field matching the regexp
+    Define and send example message
+    Receive example message with regexp value    REGEXP:.*message
+
+String message field not matching the regexp
+    Define and send example message
+    Run keyword and expect error  * does not match the RegEx *  Receive example message with regexp value    REGEXP:.*message.
+
+Comparing string message field with an invalid regexp
+    Define and send example message
+    Run keyword and expect error  Invalid RegEx *  Receive example message with regexp value    REGEXP:[0-9]++
+
+Comparing string message field with a blank regexp
+    Define and send example message
+    Receive example message with regexp value    REGEXP:
+
+Comparing string message field with a invalid ending regexp
+    Define and send example message
+    Run keyword and expect error  Invalid RegEx *  Receive example message with regexp value    REGEXP:[]
+
+Comparing integer message field with a regexp
+    Define and send example message
+    New message  exMessage  StringInHeader  header:integer_field:REGEXP:.*
+    Run keyword and expect error  * can not be matched to regular expression pattern *  Server receives message
+
 *** Keywords ***
 Setup up server for test
     Define a protocol with string field in header
@@ -24,11 +62,12 @@ Setup up server for test
 
 Define a protocol with string field in header
     New protocol    StringInHeader
-    Chars     *     string_field 
+    Uint      1     integer_field
+    Chars     *     string_field
     End protocol
 
 Define and send example message
-    New message  exMessage  StringInHeader  header:string_field:match string message
+    New message  exMessage  StringInHeader  header:string_field:match string message  header:integer_field:10
     Client sends message
 
 Receive example message matching filter
@@ -38,4 +77,9 @@ Receive example message matching filter
 Receive example message with filter value
     [arguments]    ${value}
     New message  exMessage  StringInHeader  header:string_field:${value}
-    Server receives message  header_filter=string_field
+    Server receives message   header_filter=string_field
+
+Receive example message with regexp value
+    [arguments]    ${value}
+    New message  exMessage  StringInHeader  header:string_field:${value}
+    Server receives message

--- a/src/Rammbock/core.py
+++ b/src/Rammbock/core.py
@@ -700,6 +700,8 @@ class RammbockCore(object):
         length of value and decoded as all available bytes.
 
         `value` is optional.
+        `value` could be either a "String" or a "Regular Expression" and
+        if it is a Regular Expression it must be prefixed by 'REGEXP:'.
 
         Examples:
         | chars | 16 | field | Hello World! |
@@ -708,6 +710,7 @@ class RammbockCore(object):
         | chars | charLength | field |
 
         | chars | * | field | Hello World! |
+        | chars | * | field | REGEXP:^{[a-zA-Z ]+}$ |
         """
 
         self._add_field(Char(length, name, value, terminator))

--- a/src/Rammbock/templates/message_stream.py
+++ b/src/Rammbock/templates/message_stream.py
@@ -14,6 +14,7 @@
 import time
 import threading
 import traceback
+import re
 
 from Rammbock.logger import logger
 from Rammbock.binary_tools import to_bin, to_int
@@ -100,6 +101,12 @@ class MessageStream(object):
                                      (header_filter, header_filter))
             field = header[header_filter]
             if field._type == 'chars':
+                if fields[header_filter].startswith('REGEXP:'):
+                    try:
+                        regexp = fields[header_filter].split(':')[1].strip()
+                        return bool(re.match(regexp, field.ascii))
+                    except re.error as e:
+                        raise Exception("Invalid RegEx Error : " + str(e))
                 return field.ascii == fields[header_filter]
             if field._type == 'uint':
                 return field.uint == to_int(fields[header_filter])

--- a/utest/test_templates/test_primitives.py
+++ b/utest/test_templates/test_primitives.py
@@ -146,6 +146,7 @@ class TestTemplateFieldValidation(TestCase):
         self._should_pass(UInt(2, 'field', '0x04').validate({'field': field}, {}))
         self._should_pass(UInt(2, 'field', '0x0004').validate({'field': field}, {}))
         self._should_pass(UInt(2, 'field', '(0|4)').validate({'field': field}, {}))
+        self._should_fail(UInt(2, 'field', 'REGEXP:.*').validate({'field': field}, {}), 1)
 
     def test_validate_int(self):
         field = Field('int', 'field', to_bin('0xffb8'))
@@ -154,11 +155,17 @@ class TestTemplateFieldValidation(TestCase):
         self._should_pass(Int(2, 'field', '-0x48').validate({'field': field}, {}))
         self._should_pass(Int(2, 'field', '-0x0048').validate({'field': field}, {}))
         self._should_pass(Int(2, 'field', '(0|-72)').validate({'field': field}, {}))
+        self._should_fail(Int(2, 'field', 'REGEXP:.*').validate({'field': field}, {}), 1)
 
     def test_validate_chars(self):
         field = Field('chars', 'field', 'foo\x00\x00')
+        field_regEx = Field('chars', 'field', '{ Message In Braces }')
         self._should_pass(Char(5, 'field', 'foo').validate({'field': field}, {}))
         self._should_pass(Char(5, 'field', '(what|foo|bar)').validate({'field': field}, {}))
+        self._should_pass(Char(5, 'field', 'REGEXP:^{[a-zA-Z ]+}$').validate({'field': field_regEx}, {}))
+        self._should_pass(Char(5, 'field', 'REGEXP:^foo').validate({'field': field}, {}))
+        self._should_pass(Char(5, 'field', 'REGEXP:').validate({'field': field}, {}))
+        self._should_fail(Char(5, 'field', 'REGEXP:^abc').validate({'field': field}, {}), 1)
 
     def _should_pass(self, validation):
         self.assertEquals(validation, [])


### PR DESCRIPTION
This adds support for regular expressions for matching the values of type Chars.
Example: Chars   *   <field_name>    REGEXP:<reg_ex>
The same field could also be used as header_filter to filter the messages using regular expressions. #50 
