### PR TITLE
Python 2/3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+dist: trusty
+sudo: required
+
+python:
+  - "2.7"
+  - "3.6"
+
+install:
+  - "pip install nose-cov"
+  - "pip install pep8"
+  - "pip install robotframework"
+  - "pip install six"
+  - "pip install ."
+
+script:
+  - python utest/run.py

--- a/atest/Protocols.robot
+++ b/atest/Protocols.robot
@@ -118,7 +118,7 @@ Server '${server}' should get '${msg}' from '${ip}':'${port}'
 Verify server gets from
     [Arguments]    ${ip}    ${port}    ${expected}    ${server}    ${connection}=
     ${msg}    ${from ip}    ${from port} =    Server receives binary from    name=${server}    connection=${connection}
-    Should be equal    ${msg}    ${expected}
+    Should be equal as Strings   ${msg}    ${expected}
     Should be equal    ${from ip}    ${ip}
     Should be equal as integers    ${from port}    ${port}
 

--- a/atest/basic_network_operations.robot
+++ b/atest/basic_network_operations.robot
@@ -8,12 +8,12 @@ Resource          Protocols.robot
 TCP Client sends binary to server
     Client sends binary    foo
     ${message}=    Server receives binary
-    Should be equal    ${message}    foo
+    Should be equal as strings    ${message}    foo
 
 TCP Server sends binary to client
     Server sends binary    foo
     ${message}=    Client receives binary
-    Should be equal    ${message}    foo
+    Should be equal as strings    ${message}    foo
 
 Multiple UDP clients
     [Setup]    Start two udp clients

--- a/atest/ipv6.robot
+++ b/atest/ipv6.robot
@@ -35,7 +35,7 @@ IPv6 with protocols
 Client and server send and receive binary
     Client sends binary    foo
     ${message}=    Server receives binary
-    Should be equal    ${message}    foo
+    Should be equal as strings    ${message}    foo
     Server sends binary    bar
     ${message}=    Client receives binary
-    Should be equal    ${message}    bar
+    Should be equal as strings    ${message}    bar

--- a/atest/terminated_fields.robot
+++ b/atest/terminated_fields.robot
@@ -16,7 +16,7 @@ Get message with chars and end byte long termination
     Message with chars and end byte    0x0d0a
     ${msg}    get message    arbitrary_length:foo.bar.zig
     Should be equal    foo.bar.zig    ${msg.arbitrary_length.ascii}
-    Should be equal    foo.bar.zig\r\n    ${msg.arbitrary_length._raw}
+    Should be equal as strings    foo.bar.zig\r\n    ${msg.arbitrary_length._raw}
     should be equal as integers   13    ${msg.arbitrary_length.len}
 
 Send and receive message with chars with end byte

--- a/gen_docs.py
+++ b/gen_docs.py
@@ -2,6 +2,6 @@
 from robot.libdoc import libdoc
 from os.path import join, dirname
 
-execfile(join(dirname(__file__), 'src', 'Rammbock', 'version.py'))
+exec(compile(open(join(dirname(__file__), 'src', 'Rammbock', 'version.py')).read(), 'version.py', 'exec'))
 
 libdoc(join(dirname(__file__),'src','Rammbock'), join(dirname(__file__),'Rammbock-%s.html' % VERSION))

--- a/proto/generate_message_sequence.py
+++ b/proto/generate_message_sequence.py
@@ -15,10 +15,10 @@ def _get_message_text(messages):
     return "Message content not found, run at DEBUG level to generate message contents"  
 
 def _print_element(elem, separator):
-    print '\n'.join(kw_stack)
-    print separator
-    print _get_message_text(elem.findall('msg'))
-    print '--------------------------------------'    
+    print('\n'.join(kw_stack))
+    print(separator)
+    print(_get_message_text(elem.findall('msg')))
+    print('--------------------------------------')
 
 for event, elem in ET.iterparse(source, events=('start', 'end')):
     if elem.tag not in ("kw", "test", "suite", "statistics"):

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,16 @@ from distutils.core import setup
 from os.path import join, dirname, abspath
 
 CURDIR = dirname(abspath(__file__))
-execfile(join(CURDIR, 'src', 'Rammbock', 'version.py'))
+exec(compile(open(join(CURDIR, 'src', 'Rammbock', 'version.py')).read(), 'version.py', 'exec'))
 
-setup(name         = 'robotframework-rammbock',
-      version      = VERSION,
-      description  = 'Protocol testing library for Robot Framework',
-      author       = 'Robot Framework Developers',
-      author_email = 'robotframework-users@googlegroups.com',
-      url          = 'http://github.com/robotframework/Rammbock/',
-      package_dir  = {'' : 'src'},
-      packages     = ['Rammbock', 'Rammbock.templates'],
-      long_description = open(join(CURDIR, 'README.rst')).read()
+setup(name='robotframework-rammbock',
+      version=VERSION,
+      description='Protocol testing library for Robot Framework',
+      author='Robot Framework Developers',
+      author_email='robotframework-users@googlegroups.com',
+      url='http://github.com/robotframework/Rammbock/',
+      package_dir={'': 'src'},
+      packages=['Rammbock', 'Rammbock.templates'],
+      long_description=open(join(CURDIR, 'README.rst')).read(),
+      install_requires=['robotframework', 'six']
       )

--- a/src/Rammbock/__init__.py
+++ b/src/Rammbock/__init__.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from rammbock import Rammbock
+from .rammbock import Rammbock

--- a/src/Rammbock/binary_tools.py
+++ b/src/Rammbock/binary_tools.py
@@ -15,10 +15,12 @@
 import binascii
 import struct
 
+from robot.libraries.BuiltIn import BuiltIn
+
 try:
     if bin(0):
         pass
-except NameError, name_error:
+except NameError as name_error:
     def bin(value):
         """
         Support for Python 2.5
@@ -44,8 +46,8 @@ LONGLONG = struct.Struct('>Q')
 
 def to_bin(string_value):
     if string_value in (None, ''):
-        return ''
-    string_value = str(string_value)
+        return b''
+    string_value = BuiltIn().convert_to_string(string_value)
     if string_value.startswith('0x'):
         return _hex_to_bin(string_value)
     elif string_value.startswith('0b'):
@@ -55,9 +57,9 @@ def to_bin(string_value):
 
 
 def _int_to_bin(integer):
-    if integer >= 18446744073709551616L:
+    if integer >= 18446744073709551616:
         return to_bin(hex(integer))
-    return LONGLONG.pack(integer).lstrip('\x00') or '\x00'
+    return LONGLONG.pack(integer).lstrip(b'\x00') or b'\x00'
 
 
 def _hex_to_bin(string_value):
@@ -72,7 +74,7 @@ def to_bin_of_length(length, string_value):
     if len(bin) > length:
         raise AssertionError('Too long binary value %s (max length %d)'
                              % (string_value, length))
-    return bin.rjust(length, '\x00')
+    return bin.rjust(length, b'\x00')
 
 
 def to_hex(binary):
@@ -80,7 +82,7 @@ def to_hex(binary):
 
 
 def to_0xhex(binary):
-    return '0x' + to_hex(binary)
+    return b'0x' + to_hex(binary)
 
 
 def to_binary_string_of_length(length, bytes):
@@ -136,8 +138,9 @@ def _invert(value):
 
 
 def to_int(string_value):
-    if string_value in (None, ''):
+    if string_value in (None, '', b''):
         raise Exception("No value or empty value given")
+    string_value = BuiltIn().convert_to_string(string_value)
     if string_value.startswith('0x') or string_value[:3] == '-0x':
         return int(string_value, 16)
     elif string_value.startswith('0b') or string_value[:3] == '-0b':

--- a/src/Rammbock/ordered_dict.py
+++ b/src/Rammbock/ordered_dict.py
@@ -21,15 +21,28 @@
 # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
 # Passes Python2.7's test suite and incorporates all the latest updates.
 
-try:
-    from thread import get_ident as _get_ident
-except ImportError:
-    from dummy_thread import get_ident as _get_ident
+import sys
 
-try:
-    from _abcoll import KeysView, ValuesView, ItemsView
-except ImportError:
-    pass
+from six import itervalues
+
+if sys.version_info < (3,):
+    try:
+        from thread import get_ident as _get_ident
+    except ImportError:
+        from dummy_thread import get_ident as _get_ident
+    try:
+        from collections import KeysView, ValuesView, ItemsView
+    except ImportError:
+        pass
+else:
+    try:
+        from _thread import get_ident as _get_ident
+    except ImportError:
+        from _dummy_thread import get_ident as _get_ident
+    try:
+        from collections.abc import KeysView, ValuesView, ItemsView
+    except ImportError:
+        pass
 
 
 class OrderedDict(dict):
@@ -98,7 +111,7 @@ class OrderedDict(dict):
     def clear(self):
         'od.clear() -> None.  Remove all items from od.'
         try:
-            for node in self.__map.itervalues():
+            for node in itervalues(self.__map):
                 del node[:]
             root = self.__root
             root[:] = [root, root, None]

--- a/src/Rammbock/robotbackgroundlogger.py
+++ b/src/Rammbock/robotbackgroundlogger.py
@@ -72,13 +72,13 @@ class BackgroundLogger(Logger):
 
     def _log_messages_by_thread(self, name):
         for message in self._messages.pop(name, []):
-            print message.format()
+            print(message.format())
 
     def _log_all_messages(self):
         for thread in list(self._messages):
-            print "*HTML* <b>Messages by '%s'</b>" % thread
+            print("*HTML* <b>Messages by '%s'</b>" % thread)
             for message in self._messages.pop(thread):
-                print message.format()
+                print(message.format())
 
     def reset_background_messages(self, name=None):
         with self.lock:

--- a/src/Rammbock/templates/__init__.py
+++ b/src/Rammbock/templates/__init__.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from containers import Protocol, MessageTemplate, StructTemplate, ListTemplate, \
+from .containers import Protocol, MessageTemplate, StructTemplate, ListTemplate, \
     UnionTemplate, BinaryContainerTemplate, ConditionalTemplate, TBCDContainerTemplate
-from primitives import UInt, Int, Char, PDU, Binary, Length, TBCD
+from .primitives import UInt, Int, Char, PDU, Binary, Length, TBCD

--- a/src/Rammbock/templates/message_stream.py
+++ b/src/Rammbock/templates/message_stream.py
@@ -161,7 +161,10 @@ class MessageStream(object):
     def _call_handler_function(self, func, msg):
         func = self._get_call_handler(func)
         node, connection = self._get_node_and_connection()
-        args = func.func_code.co_argcount
+        try:
+            args = func.func_code.co_argcount
+        except AttributeError:
+            args = func.__code__.co_argcount
         if args == 3:
             return func(self._protocol.library, msg, node)
         if args == 4:

--- a/utest/test_binary_tools.py
+++ b/utest/test_binary_tools.py
@@ -7,69 +7,69 @@ from Rammbock.binary_tools import to_bin, to_bin_of_length, to_hex, to_0xhex, \
 class TestBinaryConversions(TestCase):
 
     def test_empty_values_to_bin(self):
-        self.assertEquals('', to_bin(None))
-        self.assertEquals('', to_bin(''))
+        self.assertEquals(b'', to_bin(None))
+        self.assertEquals(b'', to_bin(''))
 
     def test_integer_to_bin(self):
-        self.assertEquals(to_bin(0), '\x00')
-        self.assertEquals(to_bin(5), '\x05')
-        self.assertEquals(to_bin(255), '\xff')
-        self.assertEquals(to_bin(256), '\x01\x00')
-        self.assertEquals(to_bin(18446744073709551615L), '\xff\xff\xff\xff\xff\xff\xff\xff')
+        self.assertEquals(to_bin(0), b'\x00')
+        self.assertEquals(to_bin(5), b'\x05')
+        self.assertEquals(to_bin(255), b'\xff')
+        self.assertEquals(to_bin(256), b'\x01\x00')
+        self.assertEquals(to_bin(18446744073709551615), b'\xff\xff\xff\xff\xff\xff\xff\xff')
 
     def test_string_integer_to_bin(self):
-        self.assertEquals(to_bin('0'), '\x00')
-        self.assertEquals(to_bin('5'), '\x05')
-        self.assertEquals(to_bin('255'), '\xff')
-        self.assertEquals(to_bin('256'), '\x01\x00')
-        self.assertEquals(to_bin('18446744073709551615'), '\xff\xff\xff\xff\xff\xff\xff\xff')
+        self.assertEquals(to_bin('0'), b'\x00')
+        self.assertEquals(to_bin('5'), b'\x05')
+        self.assertEquals(to_bin('255'), b'\xff')
+        self.assertEquals(to_bin('256'), b'\x01\x00')
+        self.assertEquals(to_bin('18446744073709551615'), b'\xff\xff\xff\xff\xff\xff\xff\xff')
 
     def test_binary_to_bin(self):
-        self.assertEquals(to_bin('0b0'), '\x00')
-        self.assertEquals(to_bin('0b1'), '\x01')
-        self.assertEquals(to_bin('0b1111 1111'), '\xff')
-        self.assertEquals(to_bin('0b1 0000 0000'), '\x01\x00')
-        self.assertEquals(to_bin('0b01 0b01 0b01'), '\x15')
-        self.assertEquals(to_bin('0b11' * 32), '\xff\xff\xff\xff\xff\xff\xff\xff')
-        self.assertEquals(to_bin('0b11' * 1024), '\xff\xff\xff\xff\xff\xff\xff\xff' * 32)
+        self.assertEquals(to_bin('0b0'), b'\x00')
+        self.assertEquals(to_bin('0b1'), b'\x01')
+        self.assertEquals(to_bin('0b1111 1111'), b'\xff')
+        self.assertEquals(to_bin('0b1 0000 0000'), b'\x01\x00')
+        self.assertEquals(to_bin('0b01 0b01 0b01'), b'\x15')
+        self.assertEquals(to_bin('0b11' * 32), b'\xff\xff\xff\xff\xff\xff\xff\xff')
+        self.assertEquals(to_bin('0b11' * 1024), b'\xff\xff\xff\xff\xff\xff\xff\xff' * 32)
 
     def test_hex_to_bin(self):
-        self.assertEquals(to_bin('0x0'), '\x00')
-        self.assertEquals(to_bin('0x00'), '\x00')
-        self.assertEquals(to_bin('0x5'), '\x05')
-        self.assertEquals(to_bin('0xff'), '\xff')
-        self.assertEquals(to_bin('0x100'), '\x01\x00')
-        self.assertEquals(to_bin('0x01 0x02 0x03'), '\x01\x02\x03')
+        self.assertEquals(to_bin('0x0'), b'\x00')
+        self.assertEquals(to_bin('0x00'), b'\x00')
+        self.assertEquals(to_bin('0x5'), b'\x05')
+        self.assertEquals(to_bin('0xff'), b'\xff')
+        self.assertEquals(to_bin('0x100'), b'\x01\x00')
+        self.assertEquals(to_bin('0x01 0x02 0x03'), b'\x01\x02\x03')
 
     def test_integer_larger_than_8_bytes_works(self):
-        self.assertEquals(to_bin('18446744073709551616'), '\x01\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(to_bin('18446744073709551616'), b'\x01\x00\x00\x00\x00\x00\x00\x00\x00')
 
     def test_hex_larger_than_8_bytes_works(self):
-        self.assertEquals(to_bin('0xcafebabe f00dd00d deadbeef'), '\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef')
+        self.assertEquals(to_bin('0xcafebabe f00dd00d deadbeef'), b'\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef')
 
     def test_to_bin_of_length(self):
-        self.assertEquals(to_bin_of_length(1, 0), '\x00')
-        self.assertEquals(to_bin_of_length(2, 0), '\x00\x00')
-        self.assertEquals(to_bin_of_length(3, 256), '\x00\x01\x00')
+        self.assertEquals(to_bin_of_length(1, 0), b'\x00')
+        self.assertEquals(to_bin_of_length(2, 0), b'\x00\x00')
+        self.assertEquals(to_bin_of_length(3, 256), b'\x00\x01\x00')
         self.assertRaises(AssertionError, to_bin_of_length, 1, 256)
 
     def test_to_hex(self):
-        self.assertEquals(to_hex('\x00'), '00')
-        self.assertEquals(to_hex('\x00\x00'), '0000')
-        self.assertEquals(to_hex('\x00\xff\x00'), '00ff00')
-        self.assertEquals(to_hex('\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef'), 'cafebabef00dd00ddeadbeef')
+        self.assertEquals(to_hex(b'\x00'), b'00')
+        self.assertEquals(to_hex(b'\x00\x00'), b'0000')
+        self.assertEquals(to_hex(b'\x00\xff\x00'), b'00ff00')
+        self.assertEquals(to_hex(b'\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef'), b'cafebabef00dd00ddeadbeef')
 
     def test_to_0xhex(self):
-        self.assertEquals(to_0xhex('\x00'), '0x00')
-        self.assertEquals(to_0xhex('\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef'), '0xcafebabef00dd00ddeadbeef')
+        self.assertEquals(to_0xhex(b'\x00'), b'0x00')
+        self.assertEquals(to_0xhex(b'\xca\xfe\xba\xbe\xf0\x0d\xd0\x0d\xde\xad\xbe\xef'), b'0xcafebabef00dd00ddeadbeef')
 
     def test_to_0bbinary(self):
-        self.assertEquals(to_binary_string_of_length(1, '\x00'), '0b0')
-        self.assertEquals(to_binary_string_of_length(3, '\x00'), '0b000')
-        self.assertEquals(to_binary_string_of_length(9, '\x01\xff'), '0b111111111')
-        self.assertEquals(to_binary_string_of_length(12, '\x01\xff'), '0b000111111111')
-        self.assertEquals(to_binary_string_of_length(68, '\x01\x00\x00\x00\x00\x00\x00\x00\x00'), '0b0001' + ('0000' * 16))
-        self.assertEquals(to_binary_string_of_length(2048, '\xff\xff\xff\xff\xff\xff\xff\xff' * 32), '0b' + ('11' * 1024))
+        self.assertEquals(to_binary_string_of_length(1, b'\x00'), '0b0')
+        self.assertEquals(to_binary_string_of_length(3, b'\x00'), '0b000')
+        self.assertEquals(to_binary_string_of_length(9, b'\x01\xff'), '0b111111111')
+        self.assertEquals(to_binary_string_of_length(12, b'\x01\xff'), '0b000111111111')
+        self.assertEquals(to_binary_string_of_length(68, b'\x01\x00\x00\x00\x00\x00\x00\x00\x00'), '0b0001' + ('0000' * 16))
+        self.assertEquals(to_binary_string_of_length(2048, b'\xff\xff\xff\xff\xff\xff\xff\xff' * 32), '0b' + ('11' * 1024))
 
     def test_to_tbcd_value(self):
         self.assertEquals('1', to_tbcd_value(to_bin('0b11110001')))

--- a/utest/test_messages.py
+++ b/utest/test_messages.py
@@ -30,7 +30,7 @@ class TestMessages(TestCase):
         self.assertEquals(field.int, 0x00616200)
         self.assertEquals(field.hex, '0x00616200')
         self.assertEquals(field.ascii, 'ab')
-        self.assertEquals(field.bytes, '\x00\x61\x62\x00')
+        self.assertEquals(field.bytes, b'\x00\x61\x62\x00')
         self.assertEquals(field.chars, 'ab')
         self.assertEquals(field.bin, '0b00000000' + '01100001' + '01100010' + '00000000')
 

--- a/utest/test_networking.py
+++ b/utest/test_networking.py
@@ -29,17 +29,17 @@ class _NetworkingTests(TestCase):
         return TestCase.tearDown(self)
 
     def _verify_emptying(self, server, client):
-        client.send('to connect')
+        client.send(b'to connect')
         server.receive()
-        client.send('before emptying')
-        server.send('before emptying')
+        client.send(b'before emptying')
+        server.send(b'before emptying')
         time.sleep(0.01)
         client.empty()
         server.empty()
-        client.send('after')
-        server.send('after')
-        self._assert_receive(client, 'after')
-        self._assert_receive(server, 'after')
+        client.send(b'after')
+        server.send(b'after')
+        self._assert_receive(client, b'after')
+        self._assert_receive(server, b'after')
 
     def _assert_timeout(self, node, timeout=None):
         self._assert_timeout_with_type(node, socket.timeout, timeout)
@@ -79,25 +79,25 @@ class TestNetworking(_NetworkingTests):
 
     def test_send_and_receive_udp(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'])
-        client.send('foofaa')
-        self._assert_receive(server, 'foofaa')
+        client.send(b'foofaa')
+        self._assert_receive(server, b'foofaa')
 
     def test_server_send_udp(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'])
-        server.send_to('foofaa', LOCAL_IP, ports['CLIENT_PORT'])
-        self._assert_receive(client, 'foofaa')
+        server.send_to(b'foofaa', LOCAL_IP, ports['CLIENT_PORT'])
+        self._assert_receive(client, b'foofaa')
 
     def test_server_send_tcp(self):
         server, client = self._tcp_server_and_client(ports['SERVER_PORT'])
         server.accept_connection()
-        server.send('foofaa')
-        self._assert_receive(client, 'foofaa')
+        server.send(b'foofaa')
+        self._assert_receive(client, b'foofaa')
 
     def test_send_and_receive_tcp(self):
         server, client = self._tcp_server_and_client(ports['SERVER_PORT'])
-        client.send('foofaa')
+        client.send(b'foofaa')
         server.accept_connection()
-        self._assert_receive(server, 'foofaa')
+        self._assert_receive(server, b'foofaa')
 
     def test_tcp_server_with_queued_connections(self):
         server, client = self._tcp_server_and_client(ports['SERVER_PORT'])
@@ -115,18 +115,18 @@ class TestNetworking(_NetworkingTests):
         server = TCPServer(LOCAL_IP, 1338)
         client = TCPClient()
         client.connect_to(LOCAL_IP, 1338)
-        client.send('foofaa')
+        client.send(b'foofaa')
         self.assertRaises(AssertionError, server.receive)
 
     def test_setting_port_no_ip(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'], client_ip='')
-        server.send_to('foofaa', LOCAL_IP, client.get_own_address()[1])
-        self._assert_receive(client, 'foofaa')
+        server.send_to(b'foofaa', LOCAL_IP, client.get_own_address()[1])
+        self._assert_receive(client, b'foofaa')
 
     def test_setting_ip_no_port(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], '')
-        server.send_to('foofaa', *client.get_own_address())
-        self._assert_receive(client, 'foofaa')
+        server.send_to(b'foofaa', *client.get_own_address())
+        self._assert_receive(client, b'foofaa')
 
     def test_setting_client_default_timeout(self):
         _, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'], timeout=0.1)
@@ -186,9 +186,9 @@ class TestNetworking(_NetworkingTests):
     # FIXME: this deadlocks
     def xtest_blocking_timeout(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'], timeout=0.1)
-        t = Timer(0.2, client.send, args=['foofaa'])
+        t = Timer(0.2, client.send, args=[b'foofaa'])
         t.start()
-        self.assertEquals(server.receive(timeout='blocking'), 'foofaa')
+        self.assertEquals(server.receive(timeout='blocking'), b'foofaa')
 
     def test_empty_udp_stream(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'], timeout=0.1)
@@ -204,7 +204,7 @@ class TestGetEndPoints(_NetworkingTests):
 
     def test_get_udp_endpoints(self):
         server, client = self._udp_server_and_client(ports['SERVER_PORT'], ports['CLIENT_PORT'])
-        client.send('foofaa')
+        client.send(b'foofaa')
         server.receive()
         self.assertEquals(client.get_own_address(), (LOCAL_IP, ports['CLIENT_PORT']))
         self.assertEquals(server.get_own_address(), (LOCAL_IP, ports['SERVER_PORT']))
@@ -230,7 +230,7 @@ def _get_template():
 
 class TestBufferedStream(TestCase):
 
-    DATA = 'foobardiibadaa'
+    DATA = b'foobardiibadaa'
 
     def setUp(self):
         self._buffered_stream = BufferedStream(MockConnection(self.DATA), 0.1)
@@ -239,9 +239,9 @@ class TestBufferedStream(TestCase):
         self.assertEquals(self.DATA, self._buffered_stream.read(len(self.DATA)))
 
     def test_empty(self):
-        self._buffered_stream.read(len('foobar'))
+        self._buffered_stream.read(len(b'foobar'))
         self._buffered_stream.empty()
-        self.assertRaises(AssertionError, self._buffered_stream.read, len(self.DATA) - len('foobar'))
+        self.assertRaises(AssertionError, self._buffered_stream.read, len(self.DATA) - len(b'foobar'))
 
     def test_read_all(self):
         data = self._buffered_stream.read(-1)
@@ -249,9 +249,9 @@ class TestBufferedStream(TestCase):
 
     def test_read_and_return(self):
         self._buffered_stream.read(-1)
-        self._buffered_stream.return_data('badaa')
+        self._buffered_stream.return_data(b'badaa')
         data = self._buffered_stream.read(-1)
-        self.assertEquals(data, 'badaa')
+        self.assertEquals(data, b'badaa')
 
 
 class MockConnection(object):
@@ -261,7 +261,7 @@ class MockConnection(object):
 
     def receive(self, timeout):
         ret = self._data
-        self._data = ''
+        self._data = b''
         return ret
 
 

--- a/utest/test_rammbock.py
+++ b/utest/test_rammbock.py
@@ -82,13 +82,13 @@ class TestMessageSequence(TestCase):
 
     def test_send_binary_without_protocol(self):
         self._start_client_server()
-        self.rammbock.client_sends_binary('foobar')
+        self.rammbock.client_sends_binary(b'foobar')
         self._sequence_should_equal(self.rammbock._message_sequence.get(),
                                     [['Client', '127.0.0.1:12345', 'binary', '', 'sent']])
 
     def test_receive_binary_without_protocol(self):
         self._start_client_server()
-        self.rammbock.client_sends_binary('foobar')
+        self.rammbock.client_sends_binary(b'foobar')
         self.rammbock.server_receives_binary()
         self._sequence_should_equal(self.rammbock._message_sequence.get(),
                                     [['Client', 'Server', 'binary', '', 'received']])

--- a/utest/test_templates/test_bags.py
+++ b/utest/test_templates/test_bags.py
@@ -6,7 +6,7 @@ import sys
 class TestBagSize(TestCase):
 
     def test_free_size(self):
-        self._assert_min_max('*', 0, sys.maxint)
+        self._assert_min_max('*', 0, sys.maxsize)
 
     def test_fixed_size(self):
         self._assert_min_max('1', 1, 1)

--- a/utest/test_templates/test_message_stream.py
+++ b/utest/test_templates/test_message_stream.py
@@ -18,7 +18,7 @@ class TestProtocolMessageReceiving(TestCase):
         stream = MockStream(to_bin('0xff0004cafe'))
         header, data = self._protocol.read(stream)
         self.assertEquals(header.id.hex, '0xff')
-        self.assertEquals(data, '\xca\xfe')
+        self.assertEquals(data, b'\xca\xfe')
 
 
 class TestMessageStream(TestCase):

--- a/utest/test_templates/test_message_templates.py
+++ b/utest/test_templates/test_message_templates.py
@@ -28,7 +28,7 @@ class TestMessageTemplate(TestCase):
         msg = self.tmp.encode({'field_1': 1024}, {})
         self.assertEquals(msg.field_1.int, 1024)
         self.assertEquals(msg.field_1.hex, '0x0400')
-        self.assertEquals(msg.field_1.bytes, '\x04\x00')
+        self.assertEquals(msg.field_1.bytes, b'\x04\x00')
 
     def test_encode_template_with_params(self):
         msg = self.tmp.encode({'field_1': 111, 'field_2': 222}, {})

--- a/utest/test_templates/test_primitives.py
+++ b/utest/test_templates/test_primitives.py
@@ -28,14 +28,14 @@ class TestTemplateFields(TestCase):
         self.assertEquals(field.name, "char_field")
         self.assertEquals(field.default_value, 'foo')
         self.assertEquals(field.type, 'chars')
-        self.assertEquals(field.encode({}, {}, None)._raw, 'foo\x00\x00')
-        self.assertEquals(field.encode({}, {}, None).bytes, 'foo\x00\x00')
+        self.assertEquals(field.encode({}, {}, None)._raw, b'foo\x00\x00')
+        self.assertEquals(field.encode({}, {}, None).bytes, b'foo\x00\x00')
 
     def test_set_char_value_from_message_field(self):
-        msg_field = Field('chars', 'char_field', '\x00a\x00b', aligned_len=5)
+        msg_field = Field('chars', 'char_field', b'\x00a\x00b', aligned_len=5)
         field = Char(5, "char_field", '')
-        self.assertEquals(field.encode({'char_field': msg_field}, {}, None)._raw, '\x00a\x00b\x00')
-        self.assertEquals(field.encode({'char_field': msg_field}, {}, None).bytes, '\x00a\x00b\x00')
+        self.assertEquals(field.encode({'char_field': msg_field}, {}, None)._raw, b'\x00a\x00b\x00')
+        self.assertEquals(field.encode({'char_field': msg_field}, {}, None).bytes, b'\x00a\x00b\x00')
 
     def test_binary_field(self):
         field = Binary(3, 'field', 1)
@@ -118,8 +118,8 @@ class TestLittleEndian(TestCase):
     def test_little_endian_char_decode(self):
         template = Char(5, 'field', None)
         field = template.decode('hello', None, little_endian=True)
-        self.assertEquals(field._raw, 'hello')
-        self.assertEquals(field.bytes, 'hello')
+        self.assertEquals(field._raw, b'hello')
+        self.assertEquals(field.bytes, b'hello')
         self.assertEquals(field.ascii, 'hello')
 
     def test_little_endian_uint_encode(self):
@@ -158,7 +158,7 @@ class TestTemplateFieldValidation(TestCase):
         self._should_fail(Int(2, 'field', 'REGEXP:.*').validate({'field': field}, {}), 1)
 
     def test_validate_chars(self):
-        field = Field('chars', 'field', 'foo\x00\x00')
+        field = Field('chars', 'field', b'foo\x00\x00')
         field_regEx = Field('chars', 'field', '{ Message In Braces }')
         self._should_pass(Char(5, 'field', 'foo').validate({'field': field}, {}))
         self._should_pass(Char(5, 'field', '(what|foo|bar)').validate({'field': field}, {}))


### PR DESCRIPTION
Hello!

I have made changes in the code of Rammbock library which add python 2.7 and python 3.4+ compatibility and drop support of python versions less than 2.7.
Also I added configuration file for travis-ci - [.travis.yml](https://github.com/aleskarovadi/Rammbock/blob/b9795248534caefd1eaa98088ba5ad4ed880a26f/.travis.yml) (where utests will be run).

I have tested these changes:
- **utest:** all tests pass with python 2.7 and python 3;
- **atest:** all critical tests pass with python 2.7, but three critical tests fail running with python 3 ([atest_logs.zip](https://github.com/robotframework/Rammbock/files/2755424/atest_logs.zip)).
I haven't figured out what causes these errors. They are don't affect my project because I don't need the funtionality where the tests failed. Maybe someone will fix them, if I don't do it before.

Hope my pull request will help to add support of python 3 to this library.


